### PR TITLE
Fix: Switch to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x, 17.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
Builds were broken by the shutdown of the Travis .org domain name:

https://blog.travis-ci.com/2021-05-07-orgshutdown

Switching to Github Actions instead, as per instructions here:

https://docs.github.com/en/actions/quickstart
https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml